### PR TITLE
Fix Bill object property name: now it is the same in two files.

### DIFF
--- a/src/pages/bill-detail/bill-detail.html
+++ b/src/pages/bill-detail/bill-detail.html
@@ -11,8 +11,8 @@
 
 
 <ion-content padding>
-  <img [src]="bill.image || placeholderPicture" (click)="uploadPicture(bill?.$key)" />
-  <span *ngIf="!bill.image">
+  <img [src]="bill.picture || placeholderPicture" (click)="uploadPicture(bill?.$key)" />
+  <span *ngIf="!bill.picture">
     Click the image to upload a picture of your debt/bill
   </span>
 


### PR DESCRIPTION
Bill object has a property that specifies some image. It is 'image' in
'bill-detail.html' and 'picture' in 'bill.ts'. As a result picture
not shows. I fix both name to 'picture' because there is synonym
'placeholderPicture'.